### PR TITLE
v0.1.1 - Fix NoMethod Error

### DIFF
--- a/.github/workflow/gem_deploy.yml
+++ b/.github/workflow/gem_deploy.yml
@@ -1,0 +1,10 @@
+name: Gem deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  gem_deploy:
+    uses: forward3d/github-actions-workflows/.github/workflows/gem_deploy.yml@main

--- a/Changelog
+++ b/Changelog
@@ -1,0 +1,2 @@
+0.1.1
+Change outdated  URI.escape into CGI.escape - fix NoMethod error

--- a/lib/three-sixty/client.rb
+++ b/lib/three-sixty/client.rb
@@ -105,7 +105,7 @@ module ThreeSixty
     end
 
     def querystring(query_params)
-      query_params.map { |key, value| key.to_s << '=' << URI.escape(value.to_s) }.join('&')
+      query_params.map { |key, value| key.to_s << '=' << CGI.escape(value.to_s) }.join('&')
     end
 
   end

--- a/lib/three-sixty/version.rb
+++ b/lib/three-sixty/version.rb
@@ -1,3 +1,3 @@
 module ThreeSixty
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
## Description

- Fix NoMethod error after ruby 3 migration:
    Change outdated  URI.escape into CGI.escape as suggested in https://github.com/ruby/uri/issues/14
- Add gem-deploy ci and move to version 0.1.1

